### PR TITLE
fixes double increment in a loop

### DIFF
--- a/react/guide-to-web-workers-in-react/react-worker/src/Home.js
+++ b/react/guide-to-web-workers-in-react/react-worker/src/Home.js
@@ -23,7 +23,7 @@ class Home extends Component {
     };
 
     for (let i = 0; i < 10000000; i++) {
-      userDetails.id = i++;
+      userDetails.id = i;
       userDetails.dateJoined = Date.now();
 
       users.push(userDetails);

--- a/react/guide-to-web-workers-in-react/react-worker/src/worker.js
+++ b/react/guide-to-web-workers-in-react/react-worker/src/worker.js
@@ -12,7 +12,7 @@ export default () => {
     };
 
     for (let i = 0; i < 10000000; i++) {
-      userDetails.id = i++;
+      userDetails.id = i;
       userDetails.dateJoined = Date.now();
 
       users.push(userDetails);


### PR DESCRIPTION
There is confusion when in the code you see 10000000 as a user count and than when run it's half 
![image](https://user-images.githubusercontent.com/16286018/70389346-91decd80-19be-11ea-8704-51f027629cb9.png)

The reason is the loop counter variable `i` is incremented twice. 